### PR TITLE
Adds pagination to dataTable at red_flags.py

### DIFF
--- a/red_flags.py
+++ b/red_flags.py
@@ -33,6 +33,10 @@ def html_layout():
     df_table = top.copy()
     df_table['score'] = df_table.score.apply(lambda x: round(x, 2))
     df_table.columns = ['Organismo', 'Puntaje acumulado']
+    
+    pagination_config = {"page_action": "native",
+                        "page_current": 0,
+                        "page_size":2}
 
     return [
         html.H1('Desempeño en las Contrataciones Públicas'),
@@ -45,17 +49,20 @@ def html_layout():
         html.Div(['Este es un trabajo derivado del que hizo cívico y la diaria en ', html.A('cuentasclaras.uy',
                                                                                             href='http://cuentasclaras.uy/#/buying-index')]),
 
-        html.Div('Licencia: Creative Commons Attribution-ShareAlike 4.0 International License'),
-
-        html.Strong('[TODO >>>> agregar paginado de tabla]'),
+        html.Div('Licencia: Creative Commons Attribution-ShareAlike 4.0 International License'),       
 
         html.Div(html.Strong('Cuales son los organismos con peor puntaje acumulado?')),
 
         dash_table.DataTable(
             id='table',
             columns=[{"name": i, "id": i} for i in df_table.columns],
-            data=df_table.to_dict('records'),
+            data=df_table.to_dict('records'), 
+            page_action=pagination_config["page_action"],                      
+            page_current=pagination_config["page_current"],
+            page_size=pagination_config["page_size"],       
         ),
+
+        html.Br(), # Just breaking a line to show the pagination buttons properly
 
         html.Strong('De los organismos de la tabla anterior, que puntaje sacaron cada año?'),
 


### PR DESCRIPTION
- [ x ] Adding Pagination to the data table at red_flags.py: I'd added a new variable inside html_layout() called pagination_config where you can set the number of rows to show. I didn't develop any tests for this since this is a manipulation of dash data.table parameters and review in the layout. As the initial data has only a few rows, I'd set 'page_size' to 2 just to you see the pagination working. It's worth to notice that the 'native' behavior of pagination in dash is 250 rows.

Can you clarify some points about the other issues?
- grafico de lineas con compras totales de c/u: What would be 'c/u'. I didn't get it.
- un dropdown donde podes elegir el organismo: Will this dropdown be linked with the table immediately below, filtering it, right?
- una tabla con columnas 2015,2016, etc, las filas son los diferentes atributos: When you say "los diferentes atributos", you are saying the original columns in the .csv file ["Year","OrganisationId","OrganistationShortName","OrganisationName","ConectionByAmount","SanctionedCompanies","Process","Description","CompletedInfo","ConcentrationOfSuppliers","AccumulationOfSuppliersByOrganisation","QuantityOfPurchasesByException","PerformanceIndex","QuantityOfPurchases"], right?

I wish I would help more.